### PR TITLE
fix: dockerfile builder go version to match go.mod 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use official Go image as build stage
-FROM golang:1.22 AS builder
+FROM golang:1.24.4 AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
Go versions on `go.mod` and `Dockerfile` do not match, causing the build to fail 

## Evidence
![Screenshot 2025-08-28 at 10 59 18](https://github.com/user-attachments/assets/55140826-a00b-4ab4-aa6a-ef7554e13a16)
